### PR TITLE
Add hre/feedback.h to installed files as $INC/ltsmin/feedback.h

### DIFF
--- a/src/hre/Makefile.am
+++ b/src/hre/Makefile.am
@@ -1,5 +1,8 @@
 noinst_LTLIBRARIES = libhre.la
 
+# export to install folder
+pkginclude_HEADERS = feedback.h
+
 # libhre
 libhre_la_SOURCES  = user.h internal.h provider.h
 libhre_la_SOURCES += hre_context.c context.h


### PR DESCRIPTION
It is not currently exported, yet it is referenced by ltsmin-standard.h reference file.
Probably forgotten file orphaned from 98a846986eb6a8f4d7abfbb7652f9e262993138f commit of @Meijuh