### PR TITLE
Several VSet/Sym related changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
     export DDD_NAME="ddd" &&
     export DDD_VERSION="$DDD_NAME-1.8.1" &&
     export DDD_URL="http://ddd.lip6.fr/download/$DDD_VERSION.tar.gz" &&
-    export SYLVAN_VERSION="1.1.1" &&
+    export SYLVAN_VERSION="1.3.2" &&
     export SYLVAN_URL="https://github.com/trolando/sylvan/archive/v$SYLVAN_VERSION.tar.gz" &&
     export SYLVAN_NAME="sylvan-$SYLVAN_VERSION" &&
     export MCRL2_NAME="mCRL2.tar.gz" &&

--- a/configure.ac
+++ b/configure.ac
@@ -454,14 +454,14 @@ AC_ARG_WITH([sylvan],
     [AS_HELP_STRING([--without-sylvan], [do not include Sylvan's multi-core decision diagram packages])])
 
 AS_IF([test "x$with_sylvan" != "xno"], [
-    PKG_CHECK_MODULES([SYLVAN], [sylvan >= 1.1 sylvan < 1.2],[
+    PKG_CHECK_MODULES([SYLVAN], [sylvan >= 1.3.2 sylvan < 1.4],[
         have_sylvan=yes
         SYLVAN_CPPFLAGS="$SYLVAN_CFLAGS"
         AC_SUBST(SYLVAN_CFLAGS)
         AC_SUBST(SYLVAN_CPPFLAGS)
         AC_SUBST(SYLVAN_LDFLAGS)
         AC_SUBST(SYLVAN_LIBS)],
-        [AC_MSG_WARN([Sylvan >= 1.1, < 1.2 is not installed.])])
+        [AC_MSG_WARN([Sylvan >= 1.3.2, < 1.4 is not installed.])])
 ])
 
 #AM_CONDITIONAL([HAVE_POSIX], [test x"$POSIX_SHARED" = "xyes"])

--- a/src/ldd2bdd/ldd2bdd.c
+++ b/src/ldd2bdd/ldd2bdd.c
@@ -518,7 +518,8 @@ VOID_TASK_1(actual_main, void*, arg)
     if (f == NULL) Abort("Cannot open file '%s'!", files[0]);
 
     // Init Sylvan
-    sylvan_init_package(1LL<<tablesize, 1LL<<maxtablesize, 1LL<<cachesize, 1LL<<maxcachesize);
+    sylvan_set_sizes(1LL<<tablesize, 1LL<<maxtablesize, 1LL<<cachesize, 1LL<<maxcachesize);
+    sylvan_init_package();
     sylvan_init_ldd();
     sylvan_init_mtbdd();
     sylvan_gc_hook_pregc(TASK(gc_start));

--- a/src/pins2lts-sym/Makefile.am
+++ b/src/pins2lts-sym/Makefile.am
@@ -3,15 +3,7 @@ SUBDIRS = maxsum
 SYM_CPP_FLAGS = $(AM_CPPFLAGS) $(PROFILER_CPPFLAGS)
 SYM_LD_FLAGS = $(AM_LDFLAGS) $(PROFILER_LDFLAGS)
 
-noinst_LTLIBRARIES  = libpins2lts_sym.la
-
-# libpins2lts_sym.la
-libpins2lts_sym_la_SOURCES  = pins2lts-sym.c options.h
-libpins2lts_sym_la_CPPFLAGS = $(SYM_CPP_FLAGS)
-libpins2lts_sym_la_LDFLAGS  = $(SYM_LD_FLAGS)
-
-LIBZZZ  = libpins2lts_sym.la
-LIBZZZ += ../pins-lib/libpins.la
+LIBZZZ = ../pins-lib/libpins.la
 LIBZZZ += ../vset-lib/libvset.la
 LIBZZZ += maxsum/libmaxsum.la
 LIBZZZ += ../spg-lib/libspg.la
@@ -58,7 +50,7 @@ endif
 SYM_CPP_FLAGS += $(SYLVAN_CPPFLAGS)
 
 # etf2lts-sym
-etf2lts_sym_SOURCES   = options.c
+etf2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 etf2lts_sym_SOURCES  += ../pins-lib/modules/etf-pins.c ../pins-lib/modules/etf-pins.h
 etf2lts_sym_LDADD     = $(LIBZZZ)
 etf2lts_sym_CPPFLAGS  = -DETF $(SYM_CPP_FLAGS)
@@ -66,7 +58,7 @@ etf2lts_sym_LDFLAGS   = $(SYM_LDFLAGS)
 nodist_EXTRA_etf2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # pins2lts-sym
-pins2lts_sym_SOURCES   = options.c
+pins2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 pins2lts_sym_SOURCES  += ../pins-lib/modules/dlopen-pins.c ../pins-lib/modules/dlopen-pins.h
 pins2lts_sym_LDADD     = $(LIBZZZ)
 pins2lts_sym_CPPFLAGS  = -DPINS_DLL $(SYM_CPP_FLAGS)
@@ -76,7 +68,7 @@ endif
 nodist_EXTRA_pins2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # lpo2lts-sym
-lpo2lts_sym_SOURCES   = options.c
+lpo2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 lpo2lts_sym_LDADD     = $(LIBZZZ) $(MCRL_LIBS)
 lpo2lts_sym_LDADD    += ../pins-lib/libmcrl-pins.la
 lpo2lts_sym_CPPFLAGS  = -DMCRL $(MCRL_CPPFLAGS) $(SYM_CPP_FLAGS)
@@ -84,7 +76,7 @@ lpo2lts_sym_LDFLAGS   = $(MCRL_LDFLAGS) $(SYM_LD_FLAGS)
 nodist_EXTRA_lpo2lts_sym_SOURCES = automake-force-linker.cxx # req. by mcrl
 
 # lps2lts-sym
-lps2lts_sym_SOURCES   = options.c
+lps2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 lps2lts_sym_LDADD     = $(LIBZZZ) 
 lps2lts_sym_LDADD    += ../pins-lib/libmcrl2-pins.la
 lps2lts_sym_CPPFLAGS  = -DMCRL2 $(SYM_CPP_FLAGS)
@@ -92,7 +84,7 @@ lps2lts_sym_LDFLAGS   = $(MCRL2_LDFLAGS) $(SYM_LD_FLAGS)
 nodist_EXTRA_lps2lts_sym_SOURCES = automake-force-linker.cxx # req. by mcrl2
 
 # mapa2lts-sym
-mapa2lts_sym_SOURCES   = options.c
+mapa2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 mapa2lts_sym_LDADD     = ../pins-lib/libmapa-pins.la
 mapa2lts_sym_LDADD    += $(LIBZZZ) -lscoop
 mapa2lts_sym_LDFLAGS   = -L${top_builddir}/scoop/src $(SYM_LD_FLAGS)
@@ -100,7 +92,7 @@ mapa2lts_sym_CPPFLAGS  = -DMAPA $(SYM_CPP_FLAGS)
 nodist_EXTRA_mapa2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # pbes2lts-sym
-pbes2lts_sym_SOURCES   = options.c
+pbes2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 pbes2lts_sym_LDADD     = $(LIBZZZ)
 pbes2lts_sym_LDADD    += ../pins-lib/libpbes-pins.la
 pbes2lts_sym_CPPFLAGS  = -DLTSMIN_PBES $(SYM_CPP_FLAGS)
@@ -108,7 +100,7 @@ pbes2lts_sym_LDFLAGS   = $(MCRL2_LDFLAGS) $(SYM_LD_FLAGS)
 nodist_EXTRA_pbes2lts_sym_SOURCES = automake-force-linker.cxx # req. by pbes
 
 # dve2lts-sym
-dve2lts_sym_SOURCES   = options.c
+dve2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 dve2lts_sym_SOURCES  += ../pins-lib/modules/dve-pins.c ../pins-lib/modules/dve-pins.h
 dve2lts_sym_LDADD     = $(LIBZZZ) $(DVE_LIBS)
 dve2lts_sym_CPPFLAGS  = -DDIVINE $(DIVINE_CPPFLAGS) $(SYM_CPP_FLAGS)
@@ -116,7 +108,7 @@ dve2lts_sym_LDFLAGS   = $(DIVINE_LDFLAGS) $(SYM_LD_FLAGS)
 nodist_EXTRA_dve2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # prom2lts-sym
-prom2lts_sym_SOURCES  = options.c
+prom2lts_sym_SOURCES  = options.c pins2lts-sym.c options.h
 prom2lts_sym_SOURCES += ../pins-lib/modules/prom-pins.c ../pins-lib/modules/prom-pins.h
 prom2lts_sym_LDADD    = $(LIBZZZ) $(SPINS_LIBS)
 prom2lts_sym_CPPFLAGS = -DSPINS $(SPINS_CPPFLAGS) $(SYM_CPP_FLAGS)
@@ -124,7 +116,7 @@ prom2lts_sym_LDFLAGS  = $(SPINS_LDFLAGS) $(SYM_LD_FLAGS)
 nodist_EXTRA_prom2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # pnml2lts-sym
-pnml2lts_sym_SOURCES   = options.c
+pnml2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 pnml2lts_sym_SOURCES  += ../pins-lib/modules/pnml-pins.c ../pins-lib/modules/pnml-pins.h
 pnml2lts_sym_LDADD     = $(XML_LIBS) $(LIBZZZ) ../andl-lib/libandl.la
 pnml2lts_sym_CPPFLAGS  = -DPNML $(SYM_CPP_FLAGS)
@@ -133,7 +125,7 @@ pnml2lts_sym_CFLAGS    = $(XML_CFLAGS)
 nodist_EXTRA_pnml2lts_sym_SOURCES = automake-force-linker.cxx # req. by vset
 
 # prob2lts-sym
-prob2lts_sym_SOURCES   = options.c
+prob2lts_sym_SOURCES   = options.c pins2lts-sym.c options.h
 prob2lts_sym_SOURCES  += ../pins-lib/modules/prob-pins.c ../pins-lib/modules/prob-pins.h
 prob2lts_sym_LDADD     = $(PROB_LIBS) $(LIBZZZ)
 prob2lts_sym_CPPFLAGS  = -DPROB $(SYM_CPP_FLAGS)

--- a/src/pins2lts-sym/options.c
+++ b/src/pins2lts-sym/options.c
@@ -33,6 +33,7 @@ int mu_par = 0;
 int mu_opt = 0;
 
 char* dot_dir = NULL;
+char* vset_dir = NULL;
 
 char* trc_output = NULL;
 char* trc_type   = "gcf";
@@ -223,6 +224,7 @@ struct poptOption options[] = {
     { ctl_long , 0 , POPT_ARG_STRING , NULL , 0 , "file with a CTL formula  (can be given multiple times)" , "<ctl-file>.ctl" },
     { ltl_long , 0 , POPT_ARG_STRING , NULL , 0 , "file with an LTL formula  (can be given multiple times)" , "<ltl-file>.ltl" },
     { "dot", 0, POPT_ARG_STRING, &dot_dir, 0, "directory to write dot representation of vector sets to", NULL },
+    { "save-levels", 0, POPT_ARG_STRING, &vset_dir, 0, "directory to write vset snapshots of all levels to", NULL },
     { "pg-solve" , 0 , POPT_ARG_NONE , &pgsolve_flag, 0, "Solve the generated parity game (only for symbolic tool).","" },
     { NULL, 0 , POPT_ARG_INCLUDE_TABLE, spg_solve_options , 0, "Symbolic parity game solver options", NULL},
     { "pg-write" , 0 , POPT_ARG_STRING , &pg_output, 0, "file to write symbolic parity game to","<pg-file>.spg" },

--- a/src/pins2lts-sym/options.h
+++ b/src/pins2lts-sym/options.h
@@ -47,6 +47,7 @@ extern int mu_par;
 extern int mu_opt;
 
 extern char* dot_dir;
+extern char* vset_dir;
 
 extern char* trc_output;
 extern char* trc_type;

--- a/src/pins2lts-sym/pins2lts-sym.c
+++ b/src/pins2lts-sym/pins2lts-sym.c
@@ -104,6 +104,7 @@ static long max_grp_count = 0;
 static long max_trans_count = 0;
 static long max_mu_count = 0;
 static model_t model;
+static vset_t initial, visited;
 static vrel_t *group_next;
 static vset_t *group_explored;
 static vset_t *group_tmp;
@@ -472,6 +473,45 @@ find_action(int* src, int* dst, int* cpy, int group, char* action)
     }
 
     find_trace(trace_end, 2, global_level, levels, action);
+}
+
+
+static void
+save_snapshot_vset(FILE *f)
+{
+    /* Call hook */
+    vset_pre_save(f, domain);
+
+    /* Write domain */
+    vdom_save(f, domain);
+
+    /* Write initial state */
+    vset_save(f, initial);
+
+    /* Write number of transitions and all transitions */
+    fwrite(&nGrps, sizeof(int), 1, f);
+    for (int i=0; i<nGrps; i++) vrel_save_proj(f, group_next[i]);
+    for (int i=0; i<nGrps; i++) vrel_save(f, group_next[i]);
+
+    /* Write reachable states */
+    int save_reachable = 1;
+    fwrite(&save_reachable, sizeof(int), 1, f);
+    vset_save(f, visited);
+
+    /* Call hook */
+    vset_post_save(f, domain);
+
+    /* Now write action labels */
+    int action_count = 0;
+    if (act_label != -1) action_count = pins_chunk_count(model, action_typeno);
+    fwrite(&action_count, sizeof(int), 1, f);
+    for (int i=0; i<action_count; i++) {
+        chunk ch = pins_chunk_get(model, action_typeno, i);
+        uint32_t len = ch.len;
+        char *action = ch.data;
+        fwrite(&len, sizeof(uint32_t), 1, f);
+        fwrite(action, sizeof(char), len, f);
+    }
 }
 
 struct label_add_info
@@ -1389,6 +1429,15 @@ stats_and_progress_report(vset_t current, vset_t visited, int level)
                 if (n_count > max_grp_count) max_grp_count = n_count;
             }
         }
+    }
+
+    if (vset_dir != NULL) {
+        char *file = "%s/level%03d.dd";
+        char fcbuf[snprintf(NULL, 0, file, vset_dir, level)];
+        sprintf(fcbuf, file, vset_dir, level);
+        FILE *fp = fopen(fcbuf, "w");
+        save_snapshot_vset(fp);
+        fclose(fp);
     }
     
     if (dot_dir != NULL) {
@@ -4571,7 +4620,6 @@ static void actual_main(void *arg)
     }
 
     int *src;
-    vset_t initial;
 
     if (next_union) vset_next_fn = vset_next_union_src;
 
@@ -4596,6 +4644,17 @@ static void actual_main(void *arg)
         }
     }
 
+    if (vset_dir != NULL) {
+        DIR *dir = opendir(vset_dir);
+        if (dir) {
+            closedir(dir);
+        } else if (errno == ENOENT) {
+            Abort("Option 'save-levels': directory '%s' does not exist", vset_dir);
+        } else {
+            Abort("Option 'save-levels': failed opening directory '%s'", vset_dir);
+        }
+    }
+
     init_mu_calculus();
 
     /* determine if we need to generate a symbolic parity game */
@@ -4615,7 +4674,7 @@ static void actual_main(void *arg)
     reach_timer = RTcreateTimer();
 
     /* fix level 0 */
-    vset_t visited = vset_create(domain, -1, NULL);
+    visited = vset_create(domain, -1, NULL);
     vset_copy(visited, initial);
 
     /* check the invariants at level 0 */
@@ -4637,39 +4696,7 @@ static void actual_main(void *arg)
             FILE *f = fopen(files[1], "w");
             if (f == NULL) Abort("Cannot open '%s' for writing!", files[1]);
 
-            /* Call hook */
-            vset_pre_save(f, domain);
-
-            /* Write domain */
-            vdom_save(f, domain);
-
-            /* Write initial state */
-            vset_save(f, initial);
-
-            /* Write number of transitions and all transitions */
-            fwrite(&nGrps, sizeof(int), 1, f);
-            for (int i=0; i<nGrps; i++) vrel_save_proj(f, group_next[i]);
-            for (int i=0; i<nGrps; i++) vrel_save(f, group_next[i]);
-
-            /* Write reachable states */
-            int save_reachable = 1;
-            fwrite(&save_reachable, sizeof(int), 1, f);
-            vset_save(f, visited);
-
-            /* Call hook */
-            vset_post_save(f, domain);
-
-            /* Now write action labels */
-            int action_count = 0;
-            if (act_label != -1) action_count = pins_chunk_count(model, action_typeno);
-            fwrite(&action_count, sizeof(int), 1, f);
-            for (int i=0; i<action_count; i++) {
-                chunk ch = pins_chunk_get(model, action_typeno, i);
-                uint32_t len = ch.len;
-                char *action = ch.data;
-                fwrite(&len, sizeof(uint32_t), 1, f);
-                fwrite(action, sizeof(char), len, f);
-            }
+            save_snapshot_vset(f);
 
             /* Done! */
             fclose(f);

--- a/src/tests/test-vset.c
+++ b/src/tests/test-vset.c
@@ -2,6 +2,9 @@
 
 #include <hre/user.h>
 #include <vset-lib/vector_set.h>
+#if HAVE_SYLVAN
+#include <lace.h>
+#endif
 
 static void
 test_vset_popt(poptContext con, enum poptCallbackReason reason,
@@ -360,6 +363,11 @@ main(int argc, char *argv[])
     HREinitBegin(argv[0]); // the organizer thread is called after the binary
     HREaddOptions(options,"Vector set test\n\nOptions");
     HREinitStart(&argc,&argv,0,0,NULL,NULL);
+
+#if HAVE_SYLVAN
+    lace_init(1, 0);
+    lace_startup(0, 0, 0);
+#endif
 
     vset_implementation_t vset_impl = VSET_IMPL_AUTOSELECT;
 

--- a/src/vset-lib/vector_set.c
+++ b/src/vset-lib/vector_set.c
@@ -323,6 +323,7 @@ vset_t vset_load(FILE* f, vdom_t dom){
 }
 
 vrel_t vrel_create(vdom_t dom,int k,int* proj){
+    if (dom->shared.rel_create == NULL) return vrel_create_rw(dom, k, proj, k, proj);
     vrel_t rel = dom->shared.rel_create(dom, k, proj);
     rel->expand = NULL;
     rel->expand_ctx = NULL;

--- a/src/vset-lib/vset_sylvan.c
+++ b/src/vset-lib/vset_sylvan.c
@@ -1080,7 +1080,8 @@ ltsmin_initialize_sylvan()
     Warning(info, "Initial nodes table and operation cache requires %s.", buf);
 
     // Call initializator of library (if needed)
-    sylvan_init_package(1LL<<tablesize, 1LL<<maxtablesize, 1LL<<cachesize, 1LL<<maxcachesize);
+    sylvan_set_sizes(1LL<<tablesize, 1LL<<maxtablesize, 1LL<<cachesize, 1LL<<maxcachesize);
+    sylvan_init_package();
     sylvan_set_granularity(granularity);
     sylvan_gc_hook_pregc(TASK(gc_start));
     sylvan_gc_hook_postgc(TASK(gc_end));


### PR DESCRIPTION
Revert of pins2lts-sym problematic commit; this is important because the flags in pins-impl.h are now not applied for different versions of the Sym tool.

Minor changes to vset,tests so sylvan/lddmc can be tested.

Significant changes to vset_sylvan and vset_lddmc. Now use the newest Sylvan version. Several changes are related to performance (using pointer protection for garbage collection instead of value referencing); we also improve the file format so projections are stored explicitly. Code polished, refactored, and additional comments for documentation. Small bugs in LDDmc fixed.