### PR TITLE
State labels in mucalc formulas

### DIFF
--- a/src/ltsmin-lib/mucalc-grammar.lemon
+++ b/src/ltsmin-lib/mucalc-grammar.lemon
@@ -66,6 +66,8 @@ action_expr(A) ::= NOT STRING(S).           { A = mucalc_add_action_expression(e
 
 %type proposition { int } 
 proposition(P) ::= LBRACKET ID(I) EQUALS value(V) RBRACKET.  { P = mucalc_add_proposition(env, I, V); }
+proposition(P) ::= LBRACKET ID(I) RBRACKET.                  { int V = mucalc_add_value(env, MUCALC_VALUE_NUMBER, 1);
+                                                               P = mucalc_add_proposition(env, I, V); }
 
 %type value { int }
 value(V) ::= STRING(S).                     { /*printf("STRING\n");*/ V = mucalc_add_value(env, MUCALC_VALUE_STRING, S); }


### PR DESCRIPTION
The current syntax of `mucalc` formulas allows checking state propositions `{ s = v }` where `s` designates an entry of the state vector and `v` is an integer or string value. This patch lets `s` refer to state labels too.

When `s` is not the name of a state part, it is understood as a state label and eventually checked using the `GBgetStateLabelLong` function. Syntactic sugar `{ p }` has been defined for writing Boolean state labels `{ p = 1 }`.

The changes are:

* In `pins2pins-mucalc.c`,
    * `mucalc_add_proposition_values` looks for `s` as a state label in case the identifier is not a state variable. The `state_idx` attribute of the proposition structure can now be either the index of an entry in the state vector or the index of a state label of the original model. Since their ranges coincide, state labels are enumerated from `ctx->len`, the length of the state vector.
    * `mucalc_long` and `mucalc_all` check the proposition referring to a state label (i.e. `state_idx >= ctx->len`) using `GBgetStateLabelLong`.
    * `GBaddMucalc` sets the dependency matrices based on the original state-label-info matrix for those propositions using state labels instead of state variables.
* In `mucalc-grammar.lemon`, `{ p }` has been defined as syntactic sugar for `{ p = 1 }`.

I have tested it with some examples and it works, but perhaps I have missed something, like the reason it had not been done before.