### PR TITLE
Pass proper compiler define for jittyc rewriter to mCRL2.

### DIFF
--- a/m4/acx_mcrl2.m4
+++ b/m4/acx_mcrl2.m4
@@ -37,6 +37,9 @@ AS_IF([test "x$acx_mcrl2" = "xyes"], [
     AS_IF([test "x$enable_mcrl2_jittyc" = "xno"], [
         AC_SUBST(MCRL2_PINS_CPPFLAGS, ["$MCRL2_PINS_CPPFLAGS -DDISABLE_JITTYC"])
         AC_MSG_NOTICE([disabling mCRL2 jittyc rewriter])
+    ], [
+      AC_SUBST(MCRL2_PINS_CPPFLAGS, ["$MCRL2_PINS_CPPFLAGS -DMCRL2_JITTYC_AVAILABLE"])
+        AC_MSG_NOTICE([enabling mCRL2 jittyc rewriter])
     ])
 
     mcrl2_lib_dir=""


### PR DESCRIPTION
When compiling with mCRL2 support, and when support for the jittyc rewriter is not explicitly disabled at configure time using --disable-mcrl2-jittyc, pass the compiler define MCRL2_JITTYC_AVAILABLE as a preprocessor flag.

Passing the define is required to enable the support for the jittyc rewriter in mCRL2.

It seems that currently there is no way to determine directly from an mCRL2 installation whether it supports the jittyc rewriter. I will discuss on the mCRL2 side whether this can be improved. However, at least for the 202106.0 release of mCRL2 and the current development version, this change is required. I have not tested with older releases.