### PR TITLE
Update deprecated use of 'MPI_Errhandler_set'

### DIFF
--- a/src/hre-mpi/hre_mpi.c
+++ b/src/hre-mpi/hre_mpi.c
@@ -424,7 +424,7 @@ static void mpi_start(int*argc_p,char**argv_p[],int run_threads){
     } else {
         MPI_Init(argc_p,argv_p);
     }
-    MPI_Errhandler_set(MPI_COMM_WORLD,MPI_ERRORS_ARE_FATAL);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD,MPI_ERRORS_ARE_FATAL);
     hre_context_t ctx=HREctxMPI(MPI_COMM_WORLD);
     HREmainSet(ctx);
     HREglobalSet(ctx);


### PR DESCRIPTION
In _hre_mpi.c_ the error handler for MPI was still using the old, deprecated and now removed function `MPI_Errhandler_set` rather than the new `MPI_Comm_set_errhandler`. On Ubuntu 20.04 with dependencies installed with the default version of _apt_ this breaks compilation.

See also: https://www.open-mpi.org/faq/?category=mpi-removed#mpi-1-mpi-errhandler-set