### PR TITLE
Add a HOA format input that accepts (the negation) of a language

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## March 29, 2022
+
+- Added support for input of a Hanoi Omega Automaton (HOA) rather than an LTL formula.
+Use this feature by passing --hoa instead --ltl and providing a TGBA or Buchi automaton in this format.
+
 ## February 25, 2022
 
 - Added support for Sentential Decision Diagrams (SDDs).

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AS_IF([test "x$enable_dist" != "xno"],[
 
 AC_PROG_CC_C99
 gl_EARLY
-AX_CXX_COMPILE_STDCXX_11(, [mandatory])
+AX_CXX_COMPILE_STDCXX_17(, [mandatory])
 AS_IF([test x"$ac_cv_prog_cc_c99" = xno],
   [AC_MSG_FAILURE([no acceptable C99 compiler found.])])
 AX_TRY_CFLAGS_IFELSE([-W -Wall])

--- a/doc/inc/pins-options.txt
+++ b/doc/inc/pins-options.txt
@@ -121,6 +121,36 @@ ltsmin;;
     to progress independently.
     This option is the default if edge-based atomic predicates are found
     in the LTL formula.
+
+
+*--buchi-type*='ba|spotba|tgba'::
+    Change the way a Buchi automaton is built from an LTL formula, or that the HOA file is parsed in '--hoa' mode.
++
+Three options are available, the default is ba.
+
+ba;;
+    Use embedded version of Oddoux and Gastin's ltl2ba to build the Buchi automaton from the formula. 
+
+spotba;;
+    Use Duret-Lutz et al. Spot library to build a Buchi automaton from the formula. 
+    Note this flag is only available if compiled with Spot support.
+
+tgba;;
+	Use Duret-Lutz et al. Spot library to build a Transition-based Generalized Buchi Automaton  (TGBA) from the formula. 
+    Note this flag is only available if compiled with Spot support.    
+    Use of TGBA triggers different emptiness check algorithms (renault used by default).
+
+*--hoa*='HOAFILE'::
+    Instead of providing a formula with '--ltl' directly provide an automaton using the Hanoi Omega Automata format (HOAF). 
++
+The HOA format is a generic interchange format for Buchi-like automata.
+The automaton should usually represent the negation of the desired property.
+This flag is mutually exclusive of '--ltl' flag.
+This flag is only available if built with Spot support.
+The HOA automaton provided must either be a TGBA (use '--buchi-type=tgba') or a Buchi automaton (use '--buchi-type=spotba'), 
+not a HOA with arbitrary acceptance conditions.
+The '--buchi-type' flag must be consistent with the content of the HOA file.
+
 endif::ltl[]
 
 *--por*='heur|del'::
@@ -146,6 +176,7 @@ del;;
 *--leap*::
     Use leaping partial-order reduction, by combining several disjoint
     stubborn sets sequentially.
+
 
 include::env-vars.txt[]
 

--- a/doc/inc/pins-options.txt
+++ b/doc/inc/pins-options.txt
@@ -126,7 +126,9 @@ ltsmin;;
 *--buchi-type*='ba|spotba|tgba'::
     Change the way a Buchi automaton is built from an LTL formula, or that the HOA file is parsed in '--hoa' mode.
 +
-Three options are available, the default is ba.
+LTSmin internally uses either state-based degeneralized acceptance (BA) or transition-based generalized acceptance  (TGBA).
+Two translators are possible for LTL to BA, ltl2ba or Spot. The LTL to TGBA translation relies on Spot.
+In total three options are available, the default is ba.
 
 ba;;
     Use embedded version of Oddoux and Gastin's ltl2ba to build the Buchi automaton from the formula. 
@@ -138,7 +140,7 @@ spotba;;
 tgba;;
 	Use Duret-Lutz et al. Spot library to build a Transition-based Generalized Buchi Automaton  (TGBA) from the formula. 
     Note this flag is only available if compiled with Spot support.    
-    Use of TGBA triggers different emptiness check algorithms (renault used by default).
+    Use of TGBA triggers different emptiness check algorithms.
 
 *--hoa*='HOAFILE'::
     Instead of providing a formula with '--ltl' directly provide an automaton using the Hanoi Omega Automata format (HOAF). 
@@ -147,9 +149,7 @@ The HOA format is a generic interchange format for Buchi-like automata.
 The automaton should usually represent the negation of the desired property.
 This flag is mutually exclusive of '--ltl' flag.
 This flag is only available if built with Spot support.
-The HOA automaton provided must either be a TGBA (use '--buchi-type=tgba') or a Buchi automaton (use '--buchi-type=spotba'), 
-not a HOA with arbitrary acceptance conditions.
-The '--buchi-type' flag must be consistent with the content of the HOA file.
+The HOA automaton provided will be transformed internally to a BA or a TGBA depending on the '--buchi-type' flag.
 
 endif::ltl[]
 

--- a/ltsminreconf
+++ b/ltsminreconf
@@ -2,4 +2,4 @@
 rm -f config.cache
 echo "Note: Do NOT run aclocal by yourself, even if requested by autoreconf."
 echo "      This is done automatically."
-autoreconf -i
+autoreconf -vfi

--- a/m4/ax_cxx_compile_stdcxx_17.m4
+++ b/m4/ax_cxx_compile_stdcxx_17.m4
@@ -1,0 +1,40 @@
+# hacked together from :
+# =============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+# =============================================================================
+# ported to test C++17 
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX_11([ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the C++11
+#   standard; if necessary, add switches to CXX and CXXCPP to enable
+#   support.
+#
+#   This macro is a convenience alias for calling the AX_CXX_COMPILE_STDCXX
+#   macro with the version set to C++11.  The two optional arguments are
+#   forwarded literally as the second and third argument respectively.
+#   Please see the documentation for the AX_CXX_COMPILE_STDCXX macro for
+#   more information.  If you want to use this macro, you also need to
+#   download the ax_cxx_compile_stdcxx.m4 file.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 18
+
+AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_17], [AX_CXX_COMPILE_STDCXX([17], [$1], [$2])])

--- a/src/ltsmin-lib/ltl2ba-lex-helper.c
+++ b/src/ltsmin-lib/ltl2ba-lex-helper.c
@@ -7,7 +7,7 @@
 #define LTL_RPAR ((void*)0x02)
 
 ltsmin_expr_t
-ltsmin_expr_lookup(ltsmin_expr_t e, char *text, ltsmin_expr_list_t **le_list)
+ltsmin_expr_lookup(ltsmin_expr_t e, const char *text, ltsmin_expr_list_t **le_list)
 {
     // lookup expression
     ltsmin_expr_list_t **pp_le_list = le_list;
@@ -24,7 +24,7 @@ ltsmin_expr_lookup(ltsmin_expr_t e, char *text, ltsmin_expr_list_t **le_list)
             if (strcmp((*pp_le_list)->text, text) == 0)
                 return (*pp_le_list)->expr;
         }
-        pp_le_list = (ltsmin_expr_list_t**)&((*pp_le_list)->next);
+        pp_le_list = &((*pp_le_list)->next);
     }
     // alloc room for this predicate expression
     *pp_le_list = (ltsmin_expr_list_t*) RTmalloc(sizeof(ltsmin_expr_list_t));

--- a/src/ltsmin-lib/ltl2ba-lex-helper.h
+++ b/src/ltsmin-lib/ltl2ba-lex-helper.h
@@ -14,7 +14,7 @@
 typedef struct ltsmin_expr_list_t {
     char* text;
     ltsmin_expr_t expr;
-    struct ltsmin_expr_list* next;
+    struct ltsmin_expr_list_t* next;
 } ltsmin_expr_list_t;
 
 
@@ -24,7 +24,7 @@ typedef struct ltsmin_lin_expr {
     ltsmin_expr_t lin_expr[];
 } ltsmin_lin_expr_t;
 
-ltsmin_expr_t ltsmin_expr_lookup(ltsmin_expr_t e, char* text, ltsmin_expr_list_t **le_list);
+ltsmin_expr_t ltsmin_expr_lookup(ltsmin_expr_t e, const char* text, ltsmin_expr_list_t **le_list);
 void linearize_ltsmin_expr(ltsmin_expr_t e, ltsmin_lin_expr_t **le);
 
 

--- a/src/ltsmin-lib/ltl2spot.cpp
+++ b/src/ltsmin-lib/ltl2spot.cpp
@@ -385,7 +385,7 @@ ltsmin_hoa_destroy()
 }
 
 // directly parse the given HOA file and build an ltsmin_buchi_t
-ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env) {
+ltsmin_buchi_t *ltsmin_parse_hoa_buchi(const char * hoa_file, int to_tgba, ltsmin_parse_env_t env) {
 	spot::bdd_dict_ptr dict = spot::make_bdd_dict();
 	spot::parsed_aut_ptr pa = parse_aut(hoa_file, dict);
 	bool parse_errors = pa->format_errors(std::cerr);
@@ -394,7 +394,12 @@ ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env) 
 	spot_automaton = pa->aut;
 
 	// FIXME if is_maybe
-	isTGBA = ! spot_automaton->prop_state_acc().is_true();
+	if (to_tgba) {
+		HREassert(! spot_automaton->prop_state_acc().is_true(), "Flag --buchi-type set to tgba, but HOA file %s contains a state based Buchi. Please use --buchi-type=spotba for this input.", hoa_file);
+	} else {
+		HREassert(spot_automaton->prop_state_acc().is_true(), "Flag --buchi-type set to spotbuchi, but HOA file %s contains a transition based Buchi. Please use --buchi-type=tgba for this input.", hoa_file);
+	}
+	isTGBA = to_tgba;
 
 	// linearize expression
 	const int le_size = 64;

--- a/src/ltsmin-lib/ltl2spot.cpp
+++ b/src/ltsmin-lib/ltl2spot.cpp
@@ -403,14 +403,19 @@ ltsmin_buchi_t *ltsmin_parse_hoa_buchi(const char * hoa_file, int to_tgba, ltsmi
 	bool parse_errors = pa->format_errors(std::cerr);
 	HREassert(!parse_errors, "Parse errors found in conversion of HOA to Buchi. HOA file = %s", hoa_file);
 
-	spot_automaton = pa->aut;
-
-	// FIXME if is_maybe
-	if (to_tgba) {
-		HREassert(! spot_automaton->prop_state_acc().is_true(), "Flag --buchi-type set to tgba, but HOA file %s contains a state based Buchi. Please use --buchi-type=spotba for this input.", hoa_file);
+	// convert to appropriate automaton type
+	spot::postprocessor post;
+	if (! to_tgba) {
+		// convert to basic BA
+		post.set_type(spot::postprocessor::Buchi);
+		post.set_pref(spot::postprocessor::SBAcc | spot::postprocessor::Deterministic);
 	} else {
-		HREassert(spot_automaton->prop_state_acc().is_true(), "Flag --buchi-type set to spotbuchi, but HOA file %s contains a transition based Buchi. Please use --buchi-type=tgba for this input.", hoa_file);
+		// convert to tgba
+		post.set_type(spot::postprocessor::GeneralizedBuchi);
+		post.set_pref(spot::postprocessor::Deterministic);
 	}
+	spot_automaton = post.run(pa->aut);
+
 	isTGBA = to_tgba;
 
 	std::stringstream allAP;

--- a/src/ltsmin-lib/ltl2spot.cpp
+++ b/src/ltsmin-lib/ltl2spot.cpp
@@ -396,12 +396,18 @@ ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env) 
 	// FIXME if is_maybe
 	isTGBA = ! spot_automaton->prop_state_acc().is_true();
 
+	// linearize expression
+	const int le_size = 64;
+	le = (ltsmin_lin_expr_t*) RTmalloc(sizeof(ltsmin_lin_expr_t) + le_size * sizeof(ltsmin_expr_t));
+	le->size = le_size;
+	le->count = 0;
 
 	for (spot::formula ap: spot_automaton->ap())
 	{
 		std::string ap_name = ap.ap_name();
 		int index = SIlookup(env->state_vars,  ap_name.c_str());
 		ltsmin_expr_t e = LTSminExpr(SVAR, SVAR, index, NULL, NULL);
+		linearize_ltsmin_expr(e, &le);
 		ltl_to_store(e, env);
 	}
 

--- a/src/ltsmin-lib/ltl2spot.cpp
+++ b/src/ltsmin-lib/ltl2spot.cpp
@@ -383,3 +383,27 @@ ltsmin_hoa_destroy()
 {
     spot_automaton.reset();
 }
+
+// directly parse the given HOA file and build an ltsmin_buchi_t
+ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env) {
+	spot::bdd_dict_ptr dict = spot::make_bdd_dict();
+	spot::parsed_aut_ptr pa = parse_aut(hoa_file, dict);
+	bool parse_errors = pa->format_errors(std::cerr);
+	HREassert(!parse_errors, "Parse errors found in conversion of HOA to Buchi. HOA file = %s", hoa_file);
+
+	spot_automaton = pa->aut;
+
+	// FIXME if is_maybe
+	isTGBA = ! spot_automaton->prop_state_acc().is_true();
+
+
+	for (spot::formula ap: spot_automaton->ap())
+	{
+		std::string ap_name = ap.ap_name();
+		int index = SIlookup(env->state_vars,  ap_name.c_str());
+		ltsmin_expr_t e = LTSminExpr(SVAR, SVAR, index, NULL, NULL);
+		ltl_to_store(e, env);
+	}
+
+	return create_ltsmin_buchi(spot_automaton, env);
+}

--- a/src/ltsmin-lib/ltl2spot.h
+++ b/src/ltsmin-lib/ltl2spot.h
@@ -10,8 +10,12 @@ extern "C" {
 
 #include <ltsmin-lib/ltsmin-buchi.h>
 
+// use spot to build an automaton from a parsed LTL expression
 void ltsmin_ltl2spot(ltsmin_expr_t e, int to_tgba, ltsmin_parse_env_t env);
+// transform the spot::twa automaton built by ltl2spot to an ltsmin_buchi_t
 ltsmin_buchi_t *ltsmin_hoa_buchi(ltsmin_parse_env_t env);
+// directly parse the given HOA file and build an ltsmin_buchi_t
+ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env);
 void ltsmin_hoa_destroy();
 
 #ifdef __cplusplus

--- a/src/ltsmin-lib/ltl2spot.h
+++ b/src/ltsmin-lib/ltl2spot.h
@@ -15,7 +15,7 @@ void ltsmin_ltl2spot(ltsmin_expr_t e, int to_tgba, ltsmin_parse_env_t env);
 // transform the spot::twa automaton built by ltl2spot to an ltsmin_buchi_t
 ltsmin_buchi_t *ltsmin_hoa_buchi(ltsmin_parse_env_t env);
 // directly parse the given HOA file and build an ltsmin_buchi_t
-ltsmin_buchi_t *ltsmin_parse_hoa_buchi(const char * hoa_file, int to_tgba, ltsmin_parse_env_t env);
+ltsmin_buchi_t *ltsmin_parse_hoa_buchi(const char * hoa_file, int to_tgba, ltsmin_parse_env_t env, lts_type_t ltstype);
 void ltsmin_hoa_destroy();
 
 #ifdef __cplusplus

--- a/src/ltsmin-lib/ltl2spot.h
+++ b/src/ltsmin-lib/ltl2spot.h
@@ -15,7 +15,7 @@ void ltsmin_ltl2spot(ltsmin_expr_t e, int to_tgba, ltsmin_parse_env_t env);
 // transform the spot::twa automaton built by ltl2spot to an ltsmin_buchi_t
 ltsmin_buchi_t *ltsmin_hoa_buchi(ltsmin_parse_env_t env);
 // directly parse the given HOA file and build an ltsmin_buchi_t
-ltsmin_buchi_t *ltsmin_parse_hoa_buchi(char * hoa_file, ltsmin_parse_env_t env);
+ltsmin_buchi_t *ltsmin_parse_hoa_buchi(const char * hoa_file, int to_tgba, ltsmin_parse_env_t env);
 void ltsmin_hoa_destroy();
 
 #ifdef __cplusplus

--- a/src/ltsmin-lib/ltsmin-tl.c
+++ b/src/ltsmin-lib/ltsmin-tl.c
@@ -280,8 +280,10 @@ ltl_parse_file(const char *file, ltsmin_parse_env_t env, lts_type_t ltstype)
 {
     stream_t stream = read_formula (file);
 
-    init_ltl_env(env, ltstype);
-
+	fill_env(env, ltstype);
+	
+	create_ltl_env(env);
+	
     ltsmin_parse_stream(TOKEN_EXPR,env,stream);
 
     data_format_t df = check_type_format_LTL(env->expr, env, ltstype);
@@ -291,13 +293,6 @@ ltl_parse_file(const char *file, ltsmin_parse_env_t env, lts_type_t ltstype)
     env->expr = ltl_tree_walker(env->expr);
 
     return env->expr;
-}
-
-void
-init_ltl_env(ltsmin_parse_env_t env, lts_type_t ltstype)
-{
-	fill_env(env, ltstype);
-	create_ltl_env(env);
 }
 
 static void

--- a/src/ltsmin-lib/ltsmin-tl.c
+++ b/src/ltsmin-lib/ltsmin-tl.c
@@ -280,9 +280,7 @@ ltl_parse_file(const char *file, ltsmin_parse_env_t env, lts_type_t ltstype)
 {
     stream_t stream = read_formula (file);
 
-    fill_env (env, ltstype);
-
-    create_ltl_env(env);
+    init_ltl_env(env, ltstype);
 
     ltsmin_parse_stream(TOKEN_EXPR,env,stream);
 
@@ -293,6 +291,13 @@ ltl_parse_file(const char *file, ltsmin_parse_env_t env, lts_type_t ltstype)
     env->expr = ltl_tree_walker(env->expr);
 
     return env->expr;
+}
+
+void
+init_ltl_env(ltsmin_parse_env_t env, lts_type_t ltstype)
+{
+	fill_env(env, ltstype);
+	create_ltl_env(env);
 }
 
 static void

--- a/src/ltsmin-lib/ltsmin-tl.h
+++ b/src/ltsmin-lib/ltsmin-tl.h
@@ -77,6 +77,7 @@ typedef enum {
 } LTL;
 
 extern ltsmin_expr_t ltl_parse_file(const char *,ltsmin_parse_env_t,lts_type_t);
+extern void init_ltl_env(ltsmin_parse_env_t,lts_type_t);
 
 /* Computation Tree logic */
 

--- a/src/ltsmin-lib/ltsmin-tl.h
+++ b/src/ltsmin-lib/ltsmin-tl.h
@@ -77,7 +77,6 @@ typedef enum {
 } LTL;
 
 extern ltsmin_expr_t ltl_parse_file(const char *,ltsmin_parse_env_t,lts_type_t);
-extern void init_ltl_env(ltsmin_parse_env_t,lts_type_t);
 
 /* Computation Tree logic */
 

--- a/src/pins-lib/modules/prom-pins.c
+++ b/src/pins-lib/modules/prom-pins.c
@@ -147,9 +147,9 @@ PromCompileGreyboxModel(model_t model, const char *filename)
     char *basename = gnu_basename ((char *)filename);
     // check existence of bin file
     char *bin_fname = RTmallocZero(strlen(basename) + strlen(".spins") + 1);
-    strncpy(bin_fname, basename, strlen(basename));
+    strncpy(bin_fname, basename, strlen(basename)+1);
     char *ext = bin_fname + strlen(basename);
-    strncpy(ext, ".spins", strlen(".spins"));
+    strncpy(ext, ".spins", strlen(".spins")+1);
 
     if ((ret = stat (bin_fname, &st)) != 0)
         HREassert(ret >= 0, "File not found: %s", bin_fname);

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -852,7 +852,7 @@ GBaddLTL (model_t model)
     matrix_t       *p_sl = GBgetStateLabelInfo (model);
     int             sl_count = dm_nrows (p_sl);
 
-    ctx->is_weak = is_weak(ba);
+    ctx->is_weak = PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_BA && is_weak(ba);
     int             new_sl_count;
     if (ctx->is_weak) {
         Print1 (info, "Weak Buchi automaton detected, adding non-accepting as progress label.");

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -589,16 +589,13 @@ init_ltsmin_buchi_from_hoa(model_t model, const char *hoa_file) {
         Print(info, "LTL layer using automaton file : %s", hoa_file);
         ltsmin_parse_env_t env = LTSminParseEnvCreate();
 
-		// load AP from model
-        init_ltl_env(env,GBgetLTStype(model));
-             
         // hypothesis is that : 
         // * we are called with partial order flags only if they are legal, i.e. the HOA is stutter-insensitive
         // * Edge-based labels are not used in the logic
 		// this drops a series of tests w.r.t. the init_ltsmin_buchi function.
         // e.g. struct LTL_info LTL_info = {0, 0}; check_LTL(ltl, env, &LTL_info); HREAssert...
 
-        ba = ltsmin_parse_hoa_buchi(hoa_file, PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_TGBA, env);
+        ba = ltsmin_parse_hoa_buchi(hoa_file, PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_TGBA, env, GBgetLTStype(model));
 
 
         if (ba == NULL) {
@@ -638,6 +635,7 @@ init_ltsmin_buchi(model_t model, const char *ltl_file)
     if (NULL == shared_ba && cas(&grab_ba, 0, 1)) {
         Print(info, "LTL layer: formula: %s", ltl_file);
         ltsmin_parse_env_t env = LTSminParseEnvCreate();
+        init_ltl_env(env, GBgetLTStype(model));
         ltsmin_expr_t ltl = ltl_parse_file (ltl_file, env, GBgetLTStype(model));
         struct LTL_info LTL_info = {0, 0};
         check_LTL(ltl, env, &LTL_info);

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -582,8 +582,8 @@ init_ltsmin_buchi_from_hoa(model_t model, const char *hoa_file) {
                     "Buchi type %s is not possible with -hoa, please use --buchi-type=[spotba|tgba]", buchi_type);
 
     // force LTSmin semantics
-    PINS_LTL = PINS_LTL_LTSMIN;
-
+    PINS_LTL = PINS_LTL_SPIN;
+    Print(info, "Using Spin LTL semantics");
 
     if (NULL == shared_ba && cas(&grab_ba, 0, 1)) {
         Print(info, "LTL layer using automaton file : %s", hoa_file);

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -577,10 +577,9 @@ ltsmin_buchi_t *
 init_ltsmin_buchi_from_hoa(model_t model, const char *hoa_file) {
     ltsmin_buchi_t *ba;
 
-	// currently only supporting SPOTBA type.
-	// TODO : integrate TGBA type
-    HREassert(PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_SPOTBA,
-                    "Buchi type %s is not possible with -hoa, please use --buchi-type=spotba", buchi_type);
+	// currently only supporting SPOTBA or TGBA type.
+    HREassert(PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_SPOTBA || PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_TGBA,
+                    "Buchi type %s is not possible with -hoa, please use --buchi-type=[spotba|tgba]", buchi_type);
 
     // force LTSmin semantics
     PINS_LTL = PINS_LTL_LTSMIN;
@@ -599,7 +598,7 @@ init_ltsmin_buchi_from_hoa(model_t model, const char *hoa_file) {
 		// this drops a series of tests w.r.t. the init_ltsmin_buchi function.
         // e.g. struct LTL_info LTL_info = {0, 0}; check_LTL(ltl, env, &LTL_info); HREAssert...
 
-        ba = ltsmin_parse_hoa_buchi(hoa_file, env);
+        ba = ltsmin_parse_hoa_buchi(hoa_file, PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_TGBA, env);
 
 
         if (ba == NULL) {

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -635,7 +635,6 @@ init_ltsmin_buchi(model_t model, const char *ltl_file)
     if (NULL == shared_ba && cas(&grab_ba, 0, 1)) {
         Print(info, "LTL layer: formula: %s", ltl_file);
         ltsmin_parse_env_t env = LTSminParseEnvCreate();
-        init_ltl_env(env, GBgetLTStype(model));
         ltsmin_expr_t ltl = ltl_parse_file (ltl_file, env, GBgetLTStype(model));
         struct LTL_info LTL_info = {0, 0};
         check_LTL(ltl, env, &LTL_info);

--- a/src/pins-lib/pins2pins-ltl.c
+++ b/src/pins-lib/pins2pins-ltl.c
@@ -582,6 +582,9 @@ init_ltsmin_buchi_from_hoa(model_t model, const char *hoa_file) {
     HREassert(PINS_BUCHI_TYPE == PINS_BUCHI_TYPE_SPOTBA,
                     "Buchi type %s is not possible with -hoa, please use --buchi-type=spotba", buchi_type);
 
+    // force LTSmin semantics
+    PINS_LTL = PINS_LTL_LTSMIN;
+
 
     if (NULL == shared_ba && cas(&grab_ba, 0, 1)) {
         Print(info, "LTL layer using automaton file : %s", hoa_file);


### PR DESCRIPTION
As discussed with @alaarman and with the help of @etienne-renault and @adl this PR adds a --hoa flag to ltsmin.

It's been tested and debugged with the MCC benchmark so it seems clean semantically 
This is with the flags I use, which do include POR 
I spent more testing on --buchi-type=spotbuchi than =tgba but both work with state based AP at least.

The PR includes Alfons's patch for "weak" detection so it closes https://github.com/utwente-fmt/ltsmin/issues/201

I can add tests but mine are all .c/.so inputs to pins2lts-mc there is no model for a test setup like that (at least in what I saw) and I'm unsure how many you'd like. But I have plenty of test cases maybe I send one set of files + formula + verdict and if you set it up as an example test Alfons so I can see the files I need to add/edit, and I'll generate as many as you like.

Some hacking of strings used as keys which did not have homogeneous whitespace was also added in the AP registration phase, I hope we didn't break anything for other input languages/AP.

Please don't hesitate to comment or ask for changes we tried to not too intrusive but registering AP was a bit of a pain, we end up parsing a textual formula that is the AND of all AP just to get them registered.
