### PR TITLE
Patch missing action label in LTL context

### DIFF
--- a/src/ltsmin-printtrace/lts-tracepp.c
+++ b/src/ltsmin-printtrace/lts-tracepp.c
@@ -462,7 +462,7 @@ output_csv(lts_t trace, FILE* output_file) {
             int edge_lbls[eLbls];
             trc_get_edge_label(trace, i, edge_lbls);
             for(int j=0; j<eLbls; ++j) {
-                if ((i+1)<trace->states) {
+                if ((i+1)<trace->states || i<trace->transitions) {
                     int typeno = lts_type_get_edge_label_typeno(trace->ltstype, j);
                     trace_get_type_str(trace, typeno, edge_lbls[j], BUFLEN, tmp);
                     fprintf(output_file, "%s%s", arg_sep, tmp);


### PR DESCRIPTION
We were missing one label when looking at LTL traces, because there are as many states as transitions (with the lasso).

e.g. before :
more trace.csv 
ltl:buchi,pos0_MOVE:int,pos0_STAY:int,pos0_LEFT:int,pos0_RIGHT:int,pos0_LOOK:int,pos0_TOTAL:int,pos1_MOVE:int,pos1_STAY:int,pos1_LEFT:int,pos1_RIGHT:int,pos1_LOOK:int,pos1_TOTAL:int,pos2_MOVE:int,pos2_STAY:int,pos2_LEFT:int,po
s2_RIGHT:int,pos2_LOOK:int,pos2_TOTAL:int,pos3_MOVE:int,pos3_STAY:int,pos3_LEFT:int,pos3_RIGHT:int,pos3_LOOK:int,pos3_TOTAL:int,LTLAPtower:boolean,buchi_accept:LTL_bool,weak_ltl_progress:LTL_bool,action:action
0,0,0,0,0,3,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,false,true,false,"tr0_LOOK"
0,1,0,0,0,2,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,false,true,false,"tr0_MOVE"
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,false,true,false,"tr3_LOOK"
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,1,false,true,false,
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,false,true,false,"tr3_LOOK"

After :
ltl:buchi,pos0_MOVE:int,pos0_STAY:int,pos0_LEFT:int,pos0_RIGHT:int,pos0_LOOK:int,pos0_TOTAL:int,pos1_MOVE:int,pos1_STAY:int,pos1_LEFT:int,pos1_RIGHT:int,pos1_LOOK:int,pos1_TOTAL:int,pos2_MOVE:int,pos2_STAY:int,pos2_LEFT:int,po
s2_RIGHT:int,pos2_LOOK:int,pos2_TOTAL:int,pos3_MOVE:int,pos3_STAY:int,pos3_LEFT:int,pos3_RIGHT:int,pos3_LOOK:int,pos3_TOTAL:int,LTLAPtower:boolean,buchi_accept:LTL_bool,weak_ltl_progress:LTL_bool,action:action
0,0,0,0,0,3,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,false,true,false,"tr0_LOOK"
0,1,0,0,0,2,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,false,true,false,"tr0_MOVE"
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,false,true,false,"tr3_LOOK"
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,1,false,true,false,"tr3_STAY"
0,0,0,0,0,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,false,true,false,"tr3_LOOK"

