### PR TITLE
Fixed pins interface for mCRL2

### DIFF
--- a/m4/acx_mcrl2.m4
+++ b/m4/acx_mcrl2.m4
@@ -38,7 +38,7 @@ AS_IF([test "x$acx_mcrl2" = "xyes"], [
         AC_SUBST(MCRL2_PINS_CPPFLAGS, ["$MCRL2_PINS_CPPFLAGS -DDISABLE_JITTYC"])
         AC_MSG_NOTICE([disabling mCRL2 jittyc rewriter])
     ], [
-      AC_SUBST(MCRL2_PINS_CPPFLAGS, ["$MCRL2_PINS_CPPFLAGS -DMCRL2_JITTYC_AVAILABLE"])
+      AC_SUBST(MCRL2_PINS_CPPFLAGS, ["$MCRL2_PINS_CPPFLAGS -DMCRL2_ENABLE_JITTYC"])
         AC_MSG_NOTICE([enabling mCRL2 jittyc rewriter])
     ])
 

--- a/src/pins-lib/modules/mcrl2-pins.cpp
+++ b/src/pins-lib/modules/mcrl2-pins.cpp
@@ -32,7 +32,7 @@ extern "C" {
 #include <ltsmin-lib/ltsmin-standard.h>
 }
 
-#if defined(MCRL2_JITTYC_AVAILABLE) && !defined(DISABLE_JITTYC)
+#if defined(MCRL2_ENABLE_JITTYC) && !defined(DISABLE_JITTYC)
 static const char* mcrl2_rewriter = "jittyc";
 #else
 static const char* mcrl2_rewriter = "jitty";
@@ -361,8 +361,8 @@ mcrl2_popt (poptContext con, enum poptCallbackReason reason,
         GBregisterLoader("txt", MCRL2CompileGreyboxModel);
         if (mcrl2_verbosity > 0) {
             Warning(info, "increasing mcrl2 verbosity level by %d", mcrl2_verbosity);
-            mcrl2_log_level_t level = static_cast<mcrl2_log_level_t>(static_cast<size_t>(mcrl2_logger::get_reporting_level()) + mcrl2_verbosity);
-            mcrl2_logger::set_reporting_level(level);
+            mcrl2_log_level_t level = static_cast<mcrl2_log_level_t>(static_cast<size_t>(logger::get_reporting_level()) + mcrl2_verbosity);
+            logger::set_reporting_level(level);
         }
 #ifdef DISABLE_JITTYC
         if (strcmp(mcrl2_rewriter, "jittyc") == 0) {

--- a/src/pins-lib/modules/pbes-pins.cpp
+++ b/src/pins-lib/modules/pbes-pins.cpp
@@ -23,7 +23,7 @@ extern "C" {
 
 } // end of extern "C"
 
-#if defined(MCRL2_JITTYC_AVAILABLE) && !defined(DISABLE_JITTYC)
+#if defined(MCRL2_ENABLE_JITTYC) && !defined(DISABLE_JITTYC)
 static const char* mcrl2_rewriter = "jittyc";
 #else
 static const char* mcrl2_rewriter = "jitty";
@@ -284,8 +284,8 @@ static void pbes_popt(poptContext con, enum poptCallbackReason reason,
             GBregisterLoader("pbes", PBESloadGreyboxModel);
             if (mcrl2_verbosity > 0) {
                 Warning(info, "increasing mcrl2 verbosity level by %d", mcrl2_verbosity);
-                log::log_level_t log_level = static_cast<log::log_level_t>(static_cast<size_t>(log::mcrl2_logger::get_reporting_level()) + mcrl2_verbosity);
-                log::mcrl2_logger::set_reporting_level(log_level);
+                log::log_level_t log_level = static_cast<log::log_level_t>(static_cast<size_t>(log::logger::get_reporting_level()) + mcrl2_verbosity);
+                log::logger::set_reporting_level(log_level);
             }
 #ifdef DISABLE_JITTYC
             if (strcmp(mcrl2_rewriter, "jittyc") == 0) {
@@ -401,7 +401,7 @@ void PBESloadGreyboxModel(model_t model, const char*name)
     GBsetContext(model, ctx);
 
     log::log_level_t log_level = log_active(infoLong) ? log::verbose : log::error;
-    log::mcrl2_logger::set_reporting_level(log_level);
+    log::logger::set_reporting_level(log_level);
 
     bool reset = (reset_flag==1);
     bool always_split = (always_split_flag==1);


### PR DESCRIPTION
Two small changes to accommodate for some smaller clean ups performed in mCRL2. Unfortunately the latest development version of ltsmin does not (yet) work, but the latest release build does.
 * Renamed mcrl2_logger to logger.
 * Renamed JITTYC_AVAILABLE to MCRL2_ENABLE_JITTYC.